### PR TITLE
ci(circle): Removes sourcemap deletion

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,9 +34,7 @@ jobs:
           - v1-dependencies-
       - run: yarn
       - run: yarn build
-      - run: |
-          rm dist/build.js.map
-          npx now dist -p -C -t $NOW_TOKEN -T multi-cell -n devise-staging
+      - run: npx now dist -p -C -t $NOW_TOKEN -T multi-cell -n devise-staging
 
   deploy_prod:
     docker:
@@ -51,9 +49,7 @@ jobs:
           - v1-dependencies-
       - run: yarn
       - run: yarn build
-      - run: |
-          rm dist/build.js.map
-          npx now dist -p -C -t $NOW_TOKEN -T multi-cell -n devise
+      - run: npx now dist -p -C -t $NOW_TOKEN -T multi-cell -n devise
 
 workflows:
   version: 2


### PR DESCRIPTION
Previously, we were removing sourcemaps during deployment in order to make sure everything was 1MB or less in file size. Unfortunately, we also added hashes to output names, so we can no longer just
target the map and delete it. However, we no longer need to do this, with the removal of babel-loader; I've just removed deletion altogether.

Closes #29