### PR TITLE
chore(package): update style-loader to version 0.20.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "rimraf": "^2.6.1",
     "sass-loader": "^6.0.6",
     "serve": "^6.4.1",
-    "style-loader": "^0.19.1",
+    "style-loader": "^0.20.1",
     "url-loader": "^0.6.2",
     "vue-loader": "^13.0.0",
     "vue-style-loader": "^3.0.1",


### PR DESCRIPTION
Closes #49

Update to a newer version of style-loader than the initial Greenkeeper PR.